### PR TITLE
[Fix] Fix parsing of encoded words

### DIFF
--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -416,7 +416,7 @@ phrase charsets = foldMany1Sep " " $
   -- decode them, and concatenate the result.
   fmap
     ( foldMap (decodeEncodedWord charsets) )
-    ( ("=?" *> encodedWord) `sepBy1` char8 ' ' )
+    ( many1' ((optionalCFWS *> "=?" *> encodedWord) <* optionalCFWS) )
   <|> fmap decodeLenient word
 
 displayName :: CharsetLookup -> Parser T.Text


### PR DESCRIPTION
Problem: Encoded words do not parse in email address lists.

Solution: Normal words have  optional white spaces around, but encoded words do not. That's why if there exist spaces around encoded words they are parsed as normal words. So we need just add optional white spaces around encoded words in phrase parser.